### PR TITLE
[MAIN] CN-1348: PHP 8.5 compatibility fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 TradeCentric - Xframe
 ===========
+### 1.0.5 (2026-08-03)
+* CN-1348: Added support for PHP 8.5 compatibility with Magento 2.4.9
+
 ### 1.0.3 (2025-08-12)
 * PBR-2419: Added support for PHP 8.4 compatibility with Magento 2.4.8
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -139,7 +139,7 @@ class Data extends AbstractHelper
             } else {
                 $user_value = '_no_customer';
             }
-            $this->debug('user '. $user_attribute .' => '. $user_value);
+            $this->debug('user '. $user_attribute .' => '. (string) $user_value);
             $advanced_config = $this->getConfig('punchout2go_xframe/advanced/header_advanced');
             $headers = json_decode((string) $advanced_config,true);
             if (!empty($headers)

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -141,7 +141,7 @@ class Data extends AbstractHelper
             }
             $this->debug('user '. $user_attribute .' => '. $user_value);
             $advanced_config = $this->getConfig('punchout2go_xframe/advanced/header_advanced');
-            $headers = json_decode($advanced_config,true);
+            $headers = json_decode((string) $advanced_config,true);
             if (!empty($headers)
                 && is_array($headers)) {
                 $this->debug('matching data',$headers);
@@ -152,7 +152,7 @@ class Data extends AbstractHelper
                         && isset($option['header'])) {
                         if ($option['user_value'] == $user_value) {
                             return $option['header'];
-                        } elseif ($option['user_value'] = '*') {
+                        } elseif ($option['user_value'] == '*') {
                             $default = $option['header'];
                         }
                     }
@@ -247,7 +247,7 @@ class Data extends AbstractHelper
     public function getConfigFlag($config_path)
     {
         $store = $this->storeManager->getStore()->getId();
-        return (boolean) $this->scopeConfig->getValue($config_path,'store',$store);
+        return (bool) $this->scopeConfig->getValue($config_path,'store',$store);
     }
 
 }

--- a/Logger/Handler/Debug.php
+++ b/Logger/Handler/Debug.php
@@ -38,25 +38,6 @@ class Debug extends Base
         //    $this->fileName = $this->punchout_fileName;
         //}
 
-        // check if any handler will handle this message so we can return early and save cycles
-        $handlerKey = null;
-        $level = $this->loggerType;
-
-        if (!self::$timezone) {
-            self::$timezone = new \DateTimeZone(date_default_timezone_get() ?: 'UTC');
-        }
-
-        $record = array(
-            'message'    => (string)$message,
-            'context'    => $context,
-            'level'      => $level,
-            'level_name' => 'DEBUG',
-            'channel'    => $this->name,
-            'datetime'   => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)),
-                static::$timezone)->setTimezone(static::$timezone),
-            'extra'      => array(),
-        );
-
-        $this->handle($record);
+        (new \Monolog\Logger($this->name, [$this]))->addRecord($this->loggerType, (string) $message, $context);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "OSL-3.0",
         "AFL-3.0"
     ],
-    "version": "1.0.4",
+    "version": "1.0.5",
     "require": {
         "php": "^7.0||^8.0",
         "tradecentric/module-version": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bfab070f442f61ac71f125f0a245082",
+    "content-hash": "e1dcd1fc76d780697f882a00f0a276ec",
     "packages": [
         {
             "name": "tradecentric/module-punchout",
@@ -675,5 +675,5 @@
         "php": "^7.0||^8.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary
- Fix `(boolean)` non-canonical cast in `Helper/Data.php` — deprecated in PHP 8.5, and was causing `bin/magento setup:di:compile` to fail outright on that version.
- Guard a nullable config value with a `(string)` cast before passing to `json_decode()`.
- Fix an unrelated `=` vs `==` logic bug found in the same function (advanced header wildcard/default matching was always matching regardless of the configured value).

## Test plan
- Reproduced the original compile failure on PHP 8.5 + Adobe Commerce 2.4.9, confirmed it's resolved after this fix.
- See CN-1348 for full compatibility test plan, including functional verification of the wildcard/default header matching fix.